### PR TITLE
Navigate to edit not available dialog

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -74,9 +74,9 @@ gulp.task('clean', function (ready) {
 
 gulp.task('build', ['clean', 'qext', 'less'], function () {
   gulp.src([
+    SRC + '/**/*.ng.html',
     SRC + '/**/*.json',
     SRC + '/**/*.png',
-    SRC + '/**/*.ng.html'
   ])
     .pipe(gulp.dest(DIST));
   return gulp.src(SRC + '/**/*.js')

--- a/src/popup-editunavailable.ng.html
+++ b/src/popup-editunavailable.ng.html
@@ -1,0 +1,16 @@
+<div class="lui-modal-background"></div>
+<div class="lui-dialog qlik-button-for-navigation">
+    <div class="lui-dialog__header">
+        <div class="lui-dialog__title">Edit unavailable</div>
+    </div>
+    <div class="lui-dialog__body">
+        <label>Edit mode is not available.</label>
+    </div>
+    <div class="lui-dialog__footer">
+        <button
+            class="lui-button close-button"
+            ng-click="close()"
+            name="closeButton"
+            data-tid="close-btn">Close</button>
+    </div>
+</div>

--- a/src/qlik-button-for-navigation.js
+++ b/src/qlik-button-for-navigation.js
@@ -12,9 +12,11 @@ define(
     './properties',
     './lib/js/helpers',
     'text!./template.ng.html',
+    'text!./popup-editunavailable.ng.html',
+    "qvangular",
     'css!./lib/css/main.min.css'
   ],
-  function (qlik, props, utils, ngTemplate) { // eslint-disable-line max-params
+  function (qlik, props, utils, ngTemplate, popupNoEdit, qvangular) { // eslint-disable-line max-params
     'use strict';
 
     /*
@@ -124,9 +126,17 @@ define(
               // 	break;
               // eslint-enable capitalized-comments
               case 'switchToEdit':
-                var result = qlik.navigation.setMode(qlik.navigation.EDIT); // eslint-disable-line no-case-declarations
-                if (!result.success) {
-                  window.console.error(result.errorMsg);
+                if (qlik.navigation.isModeAllowed(qlik.navigation.EDIT)) {
+                  var result = qlik.navigation.setMode(qlik.navigation.EDIT); // eslint-disable-line no-case-declarations
+                  if (!result.success) {
+                    window.console.error(result.errorMsg);
+                  }
+                } else {
+                  qvangular.getService("luiDialog").show({
+                    template: popupNoEdit,
+                    closeOnEscape: true,
+                    closeOnOutside: true,
+                  });
                 }
                 break;
               default:


### PR DESCRIPTION
-If edit mode isn't available when clicking
 a "navigate to edit"-button a dialog is shown
 instead of a big error log.

-gulp race-condition prevented template.ng.html
 from being included in the zip. Changing the
 order fixed the problem at least for now.